### PR TITLE
In a Condition, bitmask should not be applied to Value.

### DIFF
--- a/eudr.cpp
+++ b/eudr.cpp
@@ -442,7 +442,7 @@ __fastcall bool TRGCND_Deaths(condition* c){
   
   if(c->maskFlag == EUD_MASK_FLAG){
     deaths &= c->location;
-    num &= c->location;
+    // num &= c->location;  // This line should be removed
   }
   
   switch(c->modifier){


### PR DESCRIPTION
The bitmask feature of the current EUD Enabler is problematic, and won't work for the maps created using euddraft>0.8.2.9.

The actual behavior of SC:R is:
For conditions like `MemoryX(dest, cmptype, value, mask)`, the `mask` is only applied to `dest`, but not `value`.

(Credit: This bug was initially discovered by Mikochan, who currently has no GitHub account.)